### PR TITLE
fix: typo in maxDelay error message

### DIFF
--- a/src/rateLimit.ts
+++ b/src/rateLimit.ts
@@ -32,7 +32,7 @@ export function pRateLimit(
       if (quotaManager.maxDelay) {
         timerId = setTimeout(() => {
           timerId = null;
-          reject(new RateLimitTimeoutError('queue maxDelay timemout exceeded'));
+          reject(new RateLimitTimeoutError('queue maxDelay timeout exceeded'));
           next();
         }, quotaManager.maxDelay);
       }


### PR DESCRIPTION
Hello and thanks for a great project! 
Found a typo in the error message when `maxDelay` is reached